### PR TITLE
removed not needed sensio/framework-bundle

### DIFF
--- a/app/composer.json
+++ b/app/composer.json
@@ -19,7 +19,6 @@
     "league/oauth2-google": "^4.0",
     "phpdocumentor/reflection-docblock": "^5.3",
     "phpstan/phpdoc-parser": "^1.4",
-    "sensio/framework-extra-bundle": "^6.1",
     "symfony/asset": "6.3.*",
     "symfony/console": "6.3.*",
     "symfony/dotenv": "6.3.*",


### PR DESCRIPTION
the SensioFrameworkBundle is abandoned like stated here:
[https://symfony.com/bundles/SensioFrameworkExtraBundle/current/index.html](https://symfony.com/bundles/SensioFrameworkExtraBundle/current/index.html)